### PR TITLE
Map building

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -2,6 +2,9 @@ import javax.swing.*;
 
 class Main{
     public static void main(String[] args) {
+
+        UserConfiguration.tileShape= UserConfiguration.TileShape.Hexagon;
+
         JFrame frame = new JFrame("Hexagon");
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         frame.add(new MapBuilder());

--- a/src/Main.java
+++ b/src/Main.java
@@ -1,5 +1,12 @@
- class Main{
+import javax.swing.*;
+
+class Main{
     public static void main(String[] args) {
-        
+        JFrame frame = new JFrame("Hexagon");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.add(new MapBuilder());
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
     }
  }

--- a/src/Map/MapBuilder.java
+++ b/src/Map/MapBuilder.java
@@ -36,7 +36,7 @@ public class MapBuilder extends JPanel{
             if (counter==50){
                 counter=0;
                 xPoints=ShapeConverter.defaultXPositions(xDefaultOffset);
-                yPoints=Arrays.stream(yPoints).map(y->y+30).toArray();
+                yPoints=Arrays.stream(yPoints).map(y->y+list.get(0).lineOffset).toArray();
             }
         }
 
@@ -48,8 +48,7 @@ public class MapBuilder extends JPanel{
             System.out.println("x:"+ e.getPoint().x + " y:"+e.getPoint().y);
             Point click = new Point(e.getX(),e.getY());
             for (Shape element: list){
-                System.out.println("x:"+((Hexagon)element).center.x + " y:"+((Hexagon)element).center.y);
-                if (click.distance(((Hexagon)element).center) <=9){
+                if (ShapeConverter.isClicked(click,element)){
                     element.active=!element.active;
                     repaint();
                     break;

--- a/src/Map/MapBuilder.java
+++ b/src/Map/MapBuilder.java
@@ -1,0 +1,87 @@
+import java.awt.*;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.util.ArrayList;
+import java.util.Arrays;
+import javax.swing.JPanel;
+
+public class MapBuilder extends JPanel{
+
+    ArrayList<Shape> list = new ArrayList<Shape>();
+
+    public MapBuilder(){
+        setPreferredSize(new Dimension(500, 500));
+        this.addMouseListener(ml);
+
+
+        int yDefaultOffset=30;
+        int xDefaultOffset =30;
+
+        int[] xPoints=Hexagon.defaultXPositions(xDefaultOffset);
+        int[] yPoints=Hexagon.defaultYPositions(yDefaultOffset);
+
+        int counter=0;
+        for (int i=0;i<750;i++){
+
+            list.add(new Hexagon(xPoints,yPoints));
+
+            xPoints=Hexagon.shiftXPoints(xPoints);
+            yPoints=Hexagon.shiftYPoints(yPoints,(i%2==0));
+
+            counter++;
+            if (counter==50){
+                counter=0;
+                xPoints=Hexagon.defaultXPositions(xDefaultOffset);
+                yPoints=Arrays.stream(yPoints).map(y->y+30).toArray();
+            }
+        }
+
+    }
+
+    MouseListener ml = new MouseListener() {
+        @Override
+        public void mouseClicked(MouseEvent e) {
+            System.out.println("x:"+ e.getPoint().x + " y:"+e.getPoint().y);
+            Point click = new Point(e.getX(),e.getY());
+            for (Shape element: list){
+                System.out.println("x:"+((Hexagon)element).center.x + " y:"+((Hexagon)element).center.y);
+                if (click.distance(((Hexagon)element).center) <=9){
+                    element.active=!element.active;
+                    repaint();
+                    break;
+                }
+            }
+        }
+
+        @Override
+        public void mousePressed(MouseEvent e) {
+
+        }
+
+        @Override
+        public void mouseReleased(MouseEvent e) {
+
+        }
+
+        @Override
+        public void mouseEntered(MouseEvent e) {
+
+        }
+
+        @Override
+        public void mouseExited(MouseEvent e) {
+
+        }
+    };
+
+    @Override
+    public void paintComponent(Graphics g){
+        super.paintComponent(g);
+        for(Shape element: list){
+            g.setColor((!element.active)?Color.white:Color.red);
+            g.fillPolygon(element.shape);
+            g.setColor(Color.black);
+            g.drawPolygon(element.shape);
+        }
+    }
+}

--- a/src/Map/MapBuilder.java
+++ b/src/Map/MapBuilder.java
@@ -3,7 +3,6 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import javax.swing.JPanel;
 
 public class MapBuilder extends JPanel{
@@ -24,19 +23,21 @@ public class MapBuilder extends JPanel{
         xPoints=ShapeConverter.defaultXPositions(xDefaultOffset);
         yPoints=ShapeConverter.defaultYPositions(yDefaultOffset);
 
-        int counter=0;
-        for (int i=0;i<750;i++){
+        int shapeCounter=0;
+        int lineCounter=0;
+        for (int i=0;i<550;i++){
 
             list.add(ShapeConverter.newTile(xPoints,yPoints));
 
             xPoints=list.get(0).shiftXPoints(xPoints);
             yPoints=list.get(0).shiftYPoints(yPoints,(i%2==0));
 
-            counter++;
-            if (counter==50){
-                counter=0;
-                xPoints=ShapeConverter.defaultXPositions(xDefaultOffset);
-                yPoints=Arrays.stream(yPoints).map(y->y+list.get(0).lineOffset).toArray();
+            shapeCounter++;
+            if (shapeCounter==25){
+                shapeCounter=0;
+                lineCounter++;
+                xPoints=ShapeConverter.defaultXPositions(xDefaultOffset+((lineCounter%2==0)?0:list.get(0).xOffset/2));
+                yPoints=Arrays.stream(yPoints).map(y->y+list.get(0).yOffset).toArray();
             }
         }
 

--- a/src/Map/MapBuilder.java
+++ b/src/Map/MapBuilder.java
@@ -7,7 +7,7 @@ import javax.swing.JPanel;
 
 public class MapBuilder extends JPanel{
 
-    ArrayList<Shape> list = new ArrayList<Shape>();
+    ArrayList<Shape> list = new ArrayList<>();
 
     public MapBuilder(){
         setPreferredSize(new Dimension(500, 500));
@@ -17,8 +17,8 @@ public class MapBuilder extends JPanel{
         int yDefaultOffset=30;
         int xDefaultOffset =30;
 
-        int[] xPoints=null;
-        int[] yPoints=null;
+        int[] xPoints;
+        int[] yPoints;
 
         xPoints=ShapeConverter.defaultXPositions(xDefaultOffset);
         yPoints=ShapeConverter.defaultYPositions(yDefaultOffset);
@@ -30,7 +30,6 @@ public class MapBuilder extends JPanel{
             list.add(ShapeConverter.newTile(xPoints,yPoints));
 
             xPoints=list.get(0).shiftXPoints(xPoints);
-            yPoints=list.get(0).shiftYPoints(yPoints,(i%2==0));
 
             shapeCounter++;
             if (shapeCounter==25){

--- a/src/Map/MapBuilder.java
+++ b/src/Map/MapBuilder.java
@@ -3,6 +3,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import javax.swing.JPanel;
 
 public class MapBuilder extends JPanel{
@@ -17,21 +18,24 @@ public class MapBuilder extends JPanel{
         int yDefaultOffset=30;
         int xDefaultOffset =30;
 
-        int[] xPoints=Hexagon.defaultXPositions(xDefaultOffset);
-        int[] yPoints=Hexagon.defaultYPositions(yDefaultOffset);
+        int[] xPoints=null;
+        int[] yPoints=null;
+
+        xPoints=ShapeConverter.defaultXPositions(xDefaultOffset);
+        yPoints=ShapeConverter.defaultYPositions(yDefaultOffset);
 
         int counter=0;
         for (int i=0;i<750;i++){
 
-            list.add(new Hexagon(xPoints,yPoints));
+            list.add(ShapeConverter.newTile(xPoints,yPoints));
 
-            xPoints=Hexagon.shiftXPoints(xPoints);
-            yPoints=Hexagon.shiftYPoints(yPoints,(i%2==0));
+            xPoints=list.get(0).shiftXPoints(xPoints);
+            yPoints=list.get(0).shiftYPoints(yPoints,(i%2==0));
 
             counter++;
             if (counter==50){
                 counter=0;
-                xPoints=Hexagon.defaultXPositions(xDefaultOffset);
+                xPoints=ShapeConverter.defaultXPositions(xDefaultOffset);
                 yPoints=Arrays.stream(yPoints).map(y->y+30).toArray();
             }
         }

--- a/src/Map/Shapes/Hexagon.java
+++ b/src/Map/Shapes/Hexagon.java
@@ -1,0 +1,41 @@
+import javax.swing.*;
+import java.awt.*;
+import java.util.Arrays;
+
+public class Hexagon extends Shape {
+    Point center;
+    public Hexagon(int [] xPoints, int [] yPoints){
+        numberOfNodes=6;
+        center = new Point(xPoints[0],yPoints[0]-10);
+        System.out.println(center.x);
+        shape =new Polygon(xPoints,yPoints,numberOfNodes);
+        active=false;
+    }
+    public static int[] defaultXPositions(int xOffset){
+        int[] ret =  {0, 9, 9, 0, -9, -9};
+        return Arrays.stream(ret).map(x->x+xOffset).toArray();
+    }
+
+    public static int[] defaultYPositions(int yOffset){
+        int[] ret =  {10, 5, -5, -10, -5, 5};
+        return Arrays.stream(ret).map(y->y+yOffset).toArray();
+    }
+
+    static int[] shiftXPoints(int[] xPoints){
+        return Arrays.stream(xPoints).map(x->(x+9)).toArray();
+    }
+
+    static int[] shiftYPoints(int[] yPoints, boolean evenColumn){
+        int yOffset=(evenColumn)?15:-15;
+        return Arrays.stream(yPoints).map(y->y+yOffset).toArray();
+    }
+
+    public int[] getXPoints(){
+        return shape.xpoints;
+    }
+    public int[] getYPoints(){
+        return shape.ypoints;
+    }
+
+
+}

--- a/src/Map/Shapes/Hexagon.java
+++ b/src/Map/Shapes/Hexagon.java
@@ -25,17 +25,4 @@ public class Hexagon extends Shape {
     public int[] shiftXPoints(int[] xPoints){
         return Arrays.stream(xPoints).map(x->(x+xOffset)).toArray();
     }
-
-    public int[] shiftYPoints(int[] yPoints, boolean evenColumn){
-        return yPoints;
-    }
-
-    public int[] getXPoints(){
-        return shape.xpoints;
-    }
-    public int[] getYPoints(){
-        return shape.ypoints;
-    }
-
-
 }

--- a/src/Map/Shapes/Hexagon.java
+++ b/src/Map/Shapes/Hexagon.java
@@ -21,11 +21,11 @@ public class Hexagon extends Shape {
         return Arrays.stream(ret).map(y->y+yOffset).toArray();
     }
 
-    static int[] shiftXPoints(int[] xPoints){
+    public int[] shiftXPoints(int[] xPoints){
         return Arrays.stream(xPoints).map(x->(x+9)).toArray();
     }
 
-    static int[] shiftYPoints(int[] yPoints, boolean evenColumn){
+    public int[] shiftYPoints(int[] yPoints, boolean evenColumn){
         int yOffset=(evenColumn)?15:-15;
         return Arrays.stream(yPoints).map(y->y+yOffset).toArray();
     }

--- a/src/Map/Shapes/Hexagon.java
+++ b/src/Map/Shapes/Hexagon.java
@@ -1,4 +1,3 @@
-import javax.swing.*;
 import java.awt.*;
 import java.util.Arrays;
 
@@ -10,7 +9,8 @@ public class Hexagon extends Shape {
         System.out.println(center.x);
         shape =new Polygon(xPoints,yPoints,numberOfNodes);
         active=false;
-        lineOffset=30;
+        yOffset =16;
+        xOffset=18;
     }
     public static int[] defaultXPositions(int xOffset){
         int[] ret =  {0, 9, 9, 0, -9, -9};
@@ -23,12 +23,11 @@ public class Hexagon extends Shape {
     }
 
     public int[] shiftXPoints(int[] xPoints){
-        return Arrays.stream(xPoints).map(x->(x+9)).toArray();
+        return Arrays.stream(xPoints).map(x->(x+xOffset)).toArray();
     }
 
     public int[] shiftYPoints(int[] yPoints, boolean evenColumn){
-        int yOffset=(evenColumn)?15:-15;
-        return Arrays.stream(yPoints).map(y->y+yOffset).toArray();
+        return yPoints;
     }
 
     public int[] getXPoints(){

--- a/src/Map/Shapes/Shape.java
+++ b/src/Map/Shapes/Shape.java
@@ -10,7 +10,8 @@ public abstract class Shape extends JPanel {
     Point center;
    boolean active;
 
-   int lineOffset;
+   int yOffset;
+    int xOffset;
     LinkedList<Shape> neighbours;
 
     //These two function is responsible for the coordinates correct place

--- a/src/Map/Shapes/Shape.java
+++ b/src/Map/Shapes/Shape.java
@@ -16,5 +16,4 @@ public abstract class Shape extends JPanel {
 
     //These two function is responsible for the coordinates correct place
     public abstract int []shiftXPoints(int[] xPoints);
-    public abstract int []shiftYPoints(int[] xPoints, boolean evenLine);
 }

--- a/src/Map/Shapes/Shape.java
+++ b/src/Map/Shapes/Shape.java
@@ -1,0 +1,11 @@
+import javax.swing.*;
+import java.awt.*;
+import java.util.LinkedList;
+
+public abstract  class Shape extends JPanel {
+    int numberOfNodes;
+    Polygon shape;
+    Point center;
+   boolean active;
+    LinkedList<Shape> neighbours;
+}

--- a/src/Map/Shapes/Shape.java
+++ b/src/Map/Shapes/Shape.java
@@ -9,6 +9,8 @@ public abstract class Shape extends JPanel {
     Polygon shape;
     Point center;
    boolean active;
+
+   int lineOffset;
     LinkedList<Shape> neighbours;
 
     //These two function is responsible for the coordinates correct place

--- a/src/Map/Shapes/Shape.java
+++ b/src/Map/Shapes/Shape.java
@@ -2,10 +2,16 @@ import javax.swing.*;
 import java.awt.*;
 import java.util.LinkedList;
 
-public abstract  class Shape extends JPanel {
+//The Shape class is the ancestor of all the shapes of the tiles
+//It makes a much easier to store the different kind of shapes
+public abstract class Shape extends JPanel {
     int numberOfNodes;
     Polygon shape;
     Point center;
    boolean active;
     LinkedList<Shape> neighbours;
+
+    //These two function is responsible for the coordinates correct place
+    public abstract int []shiftXPoints(int[] xPoints);
+    public abstract int []shiftYPoints(int[] xPoints, boolean evenLine);
 }

--- a/src/Map/Shapes/Square.java
+++ b/src/Map/Shapes/Square.java
@@ -2,33 +2,31 @@ import javax.swing.*;
 import java.awt.*;
 import java.util.Arrays;
 
-public class Hexagon extends Shape {
+public class Square extends Shape {
     Point center;
-    public Hexagon(int [] xPoints, int [] yPoints){
-        numberOfNodes=6;
-        center = new Point(xPoints[0],yPoints[0]-10);
-        System.out.println(center.x);
+    public Square(int [] xPoints, int [] yPoints){
+        numberOfNodes=4;
+        center = new Point(xPoints[0]+10,yPoints[0]-10);
         shape =new Polygon(xPoints,yPoints,numberOfNodes);
         active=false;
-        lineOffset=30;
+        lineOffset=20;
     }
     public static int[] defaultXPositions(int xOffset){
-        int[] ret =  {0, 9, 9, 0, -9, -9};
+        int[] ret =  {-10,-10,10,10};
         return Arrays.stream(ret).map(x->x+xOffset).toArray();
     }
 
     public static int[] defaultYPositions(int yOffset){
-        int[] ret =  {10, 5, -5, -10, -5, 5};
+        int[] ret =  {10, -10, -10, 10};
         return Arrays.stream(ret).map(y->y+yOffset).toArray();
     }
 
     public int[] shiftXPoints(int[] xPoints){
-        return Arrays.stream(xPoints).map(x->(x+9)).toArray();
+        return Arrays.stream(xPoints).map(x->(x+20)).toArray();
     }
 
     public int[] shiftYPoints(int[] yPoints, boolean evenColumn){
-        int yOffset=(evenColumn)?15:-15;
-        return Arrays.stream(yPoints).map(y->y+yOffset).toArray();
+        return yPoints;
     }
 
     public int[] getXPoints(){

--- a/src/Map/Shapes/Square.java
+++ b/src/Map/Shapes/Square.java
@@ -1,4 +1,3 @@
-import javax.swing.*;
 import java.awt.*;
 import java.util.Arrays;
 
@@ -9,7 +8,8 @@ public class Square extends Shape {
         center = new Point(xPoints[0]+10,yPoints[0]-10);
         shape =new Polygon(xPoints,yPoints,numberOfNodes);
         active=false;
-        lineOffset=20;
+        yOffset =20;
+        xOffset=0;
     }
     public static int[] defaultXPositions(int xOffset){
         int[] ret =  {-10,-10,10,10};

--- a/src/Map/Shapes/Square.java
+++ b/src/Map/Shapes/Square.java
@@ -25,16 +25,5 @@ public class Square extends Shape {
         return Arrays.stream(xPoints).map(x->(x+20)).toArray();
     }
 
-    public int[] shiftYPoints(int[] yPoints, boolean evenColumn){
-        return yPoints;
-    }
-
-    public int[] getXPoints(){
-        return shape.xpoints;
-    }
-    public int[] getYPoints(){
-        return shape.ypoints;
-    }
-
 
 }

--- a/src/ShapeConverter.java
+++ b/src/ShapeConverter.java
@@ -1,0 +1,34 @@
+//The ShapeConverter's main task is to help the other classes to work with the different kinds of shapes
+public class ShapeConverter {
+
+    public static Shape newTile(int[] xPoints,int[] yPoints){
+        switch (UserConfiguration.tileShape){
+            case Square:{
+                break;
+            }
+            case Hexagon:
+                return new Hexagon(xPoints,yPoints);
+            default:
+                return null;
+        }
+        return null;
+    }
+
+    public static int[] defaultXPositions(int xOffset){
+        switch (UserConfiguration.tileShape){
+            case Hexagon:{
+                return Hexagon.defaultXPositions(xOffset);
+            }
+        }
+        return null;
+    }
+    public static int[] defaultYPositions(int yOffset){
+        switch (UserConfiguration.tileShape){
+            case Hexagon:{
+                return Hexagon.defaultYPositions(yOffset);
+            }
+        }
+        return null;
+    }
+
+}

--- a/src/ShapeConverter.java
+++ b/src/ShapeConverter.java
@@ -1,39 +1,39 @@
-import org.w3c.dom.events.Event;
-
 import java.awt.*;
 
 //The ShapeConverter's main task is to help the other classes to work with the different kinds of shapes
 public class ShapeConverter {
 
     public static Shape newTile(int[] xPoints,int[] yPoints){
-        switch (UserConfiguration.tileShape){
-            case Square:{
-                return new Square(xPoints,yPoints);
+        switch (UserConfiguration.tileShape) {
+            case Square -> {
+                return new Square(xPoints, yPoints);
             }
-            case Hexagon:
-                return new Hexagon(xPoints,yPoints);
-            default:
+            case Hexagon -> {
+                return new Hexagon(xPoints, yPoints);
+            }
+            default -> {
                 return null;
+            }
         }
     }
 
     public static int[] defaultXPositions(int xOffset){
-        switch (UserConfiguration.tileShape){
-            case Hexagon:{
+        switch (UserConfiguration.tileShape) {
+            case Hexagon -> {
                 return Hexagon.defaultXPositions(xOffset);
             }
-            case Square:{
+            case Square -> {
                 return Square.defaultXPositions(xOffset);
             }
         }
         return null;
     }
     public static int[] defaultYPositions(int yOffset){
-        switch (UserConfiguration.tileShape){
-            case Hexagon:{
+        switch (UserConfiguration.tileShape) {
+            case Hexagon -> {
                 return Hexagon.defaultYPositions(yOffset);
             }
-            case Square:{
+            case Square -> {
                 return Square.defaultYPositions(yOffset);
             }
         }
@@ -41,13 +41,10 @@ public class ShapeConverter {
     }
 
     public static boolean isClicked(Point click, Shape shape){
-        switch (UserConfiguration.tileShape){
-            case Square:
-                return click.distance(((Square)shape).center) <=9;
-            case Hexagon:
-               return click.distance(((Hexagon)shape).center) <=9;
-        }
-        return false;
+        return switch (UserConfiguration.tileShape) {
+            case Square -> click.distance(((Square) shape).center) <= 9;
+            case Hexagon -> click.distance(((Hexagon) shape).center) <= 9;
+        };
     }
 
 }

--- a/src/ShapeConverter.java
+++ b/src/ShapeConverter.java
@@ -1,23 +1,29 @@
+import org.w3c.dom.events.Event;
+
+import java.awt.*;
+
 //The ShapeConverter's main task is to help the other classes to work with the different kinds of shapes
 public class ShapeConverter {
 
     public static Shape newTile(int[] xPoints,int[] yPoints){
         switch (UserConfiguration.tileShape){
             case Square:{
-                break;
+                return new Square(xPoints,yPoints);
             }
             case Hexagon:
                 return new Hexagon(xPoints,yPoints);
             default:
                 return null;
         }
-        return null;
     }
 
     public static int[] defaultXPositions(int xOffset){
         switch (UserConfiguration.tileShape){
             case Hexagon:{
                 return Hexagon.defaultXPositions(xOffset);
+            }
+            case Square:{
+                return Square.defaultXPositions(xOffset);
             }
         }
         return null;
@@ -27,8 +33,21 @@ public class ShapeConverter {
             case Hexagon:{
                 return Hexagon.defaultYPositions(yOffset);
             }
+            case Square:{
+                return Square.defaultYPositions(yOffset);
+            }
         }
         return null;
+    }
+
+    public static boolean isClicked(Point click, Shape shape){
+        switch (UserConfiguration.tileShape){
+            case Square:
+                return click.distance(((Square)shape).center) <=9;
+            case Hexagon:
+               return click.distance(((Hexagon)shape).center) <=9;
+        }
+        return false;
     }
 
 }

--- a/src/UserConfiguration.java
+++ b/src/UserConfiguration.java
@@ -1,0 +1,10 @@
+public class UserConfiguration {
+    enum TileShape{
+        Square,
+        Hexagon
+    }
+    public static TileShape tileShape;
+
+
+
+}


### PR DESCRIPTION
MapBuilder is able to handle different kinds of shapes. The Shape class allows its inheritors to use its abstract classes for compatibility. With the ShapeConverter class, MapBuilder doesn’t need to know which shape it is using.